### PR TITLE
Corrected spelling of RCC_WaitForPLLSturtUp to RCC_WaitForPLLStartUp …

### DIFF
--- a/Task-3-SystemClocks/inc/startup.h
+++ b/Task-3-SystemClocks/inc/startup.h
@@ -2,4 +2,4 @@
 #include "stm32f4xx_rcc.h"
 
 uint32_t SystemInit(void);
-void RCC_WaitForPLLSturtUp(void);
+void RCC_WaitForPLLStartUp(void);

--- a/Task-3-SystemClocks/src/main.c
+++ b/Task-3-SystemClocks/src/main.c
@@ -50,7 +50,7 @@ void slowMode() {
     RCC_PLLConfig(RCC_PLLSource_HSE, 8, 192, 8, 15);
     RCC_PLLCmd(ENABLE);
 
-    RCC_WaitForPLLSturtUp();
+    RCC_WaitForPLLStartUp();
 
     RCC_HCLKConfig(RCC_SYSCLK_Div16);
     RCC_PCLK1Config(RCC_HCLK_Div16);
@@ -71,7 +71,7 @@ void fastMode() {
     RCC_PLLConfig(RCC_PLLSource_HSE, 8, 336, 2, 15);
     RCC_PLLCmd(ENABLE);
 
-    RCC_WaitForPLLSturtUp();
+    RCC_WaitForPLLStartUp();
 
     RCC_HCLKConfig(RCC_SYSCLK_Div4);
     RCC_PCLK1Config(RCC_HCLK_Div1);

--- a/Task-3-SystemClocks/src/startup.c
+++ b/Task-3-SystemClocks/src/startup.c
@@ -9,7 +9,7 @@ uint32_t SystemInit(void) {
     RCC_PLLConfig(RCC_PLLSource_HSE, 8, 336, 4, 7);
     RCC_PLLCmd(ENABLE);
 
-    RCC_WaitForPLLSturtUp();
+    RCC_WaitForPLLStartUp();
 
     RCC_HCLKConfig(RCC_SYSCLK_Div4);
     RCC_PCLK1Config(RCC_HCLK_Div1);
@@ -18,7 +18,7 @@ uint32_t SystemInit(void) {
     return ENABLE;
 }
 
-void RCC_WaitForPLLSturtUp(void) {
+void RCC_WaitForPLLStartUp(void) {
     while ( (RCC->CR & RCC_CR_PLLRDY) == 0 ) {
         __NOP();
     }


### PR DESCRIPTION
…in Task-3-SystemClocks